### PR TITLE
Switch to cloudapi v3

### DIFF
--- a/composite_test.go
+++ b/composite_test.go
@@ -13,16 +13,6 @@ func TestCompositeCreate(t *testing.T) {
 	setupTestEnv()
 	location := "us/las"
 
-	ipblockreq := IpBlock{
-		Properties: IpBlockProperties{
-			Size:     1,
-			Location: location,
-		},
-	}
-
-	ipblockresp := ReserveIpBlock(ipblockreq)
-	ipId = ipblockresp.Id
-	fmt.Println(ipId)
 	datacenter := Datacenter{
 		Properties: DatacenterProperties{
 			Name:     "composite test",
@@ -38,19 +28,9 @@ func TestCompositeCreate(t *testing.T) {
 					},
 				},
 			},
-			Loadbalancers: &Loadbalancers{
-				Items: []Loadbalancer{
-					Loadbalancer{
-						Properties: LoadbalancerProperties{
-							Name: "test",
-						},
-					},
-				},
-			},
 		},
 	}
 
-	fmt.Println(ipblockresp.Properties.Ips)
 	dc := CompositeCreateDatacenter(datacenter)
 	dcID = dc.Id
 	waitTillProvisioned(dc.Headers.Get("Location"))
@@ -71,7 +51,7 @@ func TestCompositeCreate(t *testing.T) {
 							Type:    "HDD",
 							Size:    10,
 							Name:    "volume1",
-							Image:   "1f46a4a3-3f47-11e6-91c6-52540005ab80",
+							Image:   "a410fd07-57e6-11e6-ba9b-52540005ab80",
 							Bus:     "VIRTIO",
 							SshKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCoLVLHON4BSK3D8L4H79aFo+0cj7VM2NiRR/K9wrfkK/XiTc7FlEU4Bs8WLZcsIOxbCGWn2zKZmrLaxYlY+/3aJrxDxXYCy8lRUMnqcQ2JCFY6tpZt/DylPhS9L6qYNpJ0F4FlqRsWxsjpF8TDdJi64k2JFJ8TkvX36P2/kqyFfI+N0/axgjhqV3BgNgApvMt9jxWB5gi8LgDpw9b+bHeMS7TrAVDE7bzT86dmfbTugtiME8cIday8YcRb4xAFgRH8XJVOcE3cs390V/dhgCKy1P5+TjQMjKbFIy2LJoxb7bd38kAl1yafZUIhI7F77i7eoRidKV71BpOZsaPEbWUP jasmin@Jasmins-MBP"},
 						},
@@ -84,7 +64,6 @@ func TestCompositeCreate(t *testing.T) {
 						Properties: NicProperties{
 							Name: "nic",
 							Lan:  lan_id,
-							Ips:  ipblockresp.Properties.Ips,
 						},
 					},
 				},
@@ -94,17 +73,6 @@ func TestCompositeCreate(t *testing.T) {
 
 	server = CreateServer(dcID, server)
 	waitTillProvisioned(server.Headers.Get("Location"))
-	//lanrequest := CreateLanRequest{
-	//	LanProperties: LanProperties{
-	//		Public: true,
-	//	},
-	//}
-	//
-	//lan := CreateLan(dcID, lanrequest)
-	//
-	//obj := PatchNic(dcID, dc.Entities.Servers.Items[0].Id, dc.Entities.Servers.Items[0].Entities.Nics.Items[0].Id, NicProperties{Lan: lan.Id})
-	//
-	//waitTillProvisioned(obj.Headers.Get("Location"))
 
 	for i := 0; i < 10; i++ {
 		request := GetDatacenter(dcID)
@@ -125,12 +93,5 @@ func TestDeleteDC(t *testing.T) {
 		t.Errorf(bad_status(want, resp.StatusCode))
 	}
 
-	time.Sleep(60 * time.Second)
-
-	resp = ReleaseIpBlock(ipId)
-
-	if resp.StatusCode != want {
-		t.Errorf(bad_status(want, resp.StatusCode))
-	}
-
+	waitTillProvisioned(resp.Headers.Get("Location"))
 }

--- a/composite_test.go
+++ b/composite_test.go
@@ -2,7 +2,6 @@ package profitbricks
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -11,7 +10,7 @@ import (
 var ipId string
 
 func TestCompositeCreate(t *testing.T) {
-	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
+	setupTestEnv()
 	location := "us/las"
 
 	ipblockreq := IpBlock{
@@ -54,7 +53,6 @@ func TestCompositeCreate(t *testing.T) {
 	fmt.Println(ipblockresp.Properties.Ips)
 	dc := CompositeCreateDatacenter(datacenter)
 	dcID = dc.Id
-
 	waitTillProvisioned(dc.Headers.Get("Location"))
 	SetDepth("5")
 

--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
 package profitbricks
 
-// Endpoint is the base url for REST requests .
-var Endpoint = "https://api.profitbricks.com/rest/v2"
+// Endpoint is the base url for REST requests.
+var Endpoint = "https://api.profitbricks.com/cloudapi/v3"
 
 //  Username for authentication .
 var Username string

--- a/config_test.go
+++ b/config_test.go
@@ -17,9 +17,7 @@ func bad_status(wanted, got int) string {
 var passwd = os.Getenv("PB_PASSWORD")*/
 var username = os.Getenv("PROFITBRICKS_USERNAME")
 var passwd = os.Getenv("PROFITBRICKS_PASSWORD")
-
-// Set Endpoint for testing
-var endpoint = "https://api.profitbricks.com/rest/v2"
+var endpoint = os.Getenv("PROFITBRICKS_API_URL")
 
 func TestSetAuth(t *testing.T) {
 	fmt.Println("Current Username ", Username)
@@ -39,7 +37,7 @@ func TestMain(m *testing.M) {
 }
 
 // Setup creds for single running tests
-func setupCredentials() {
-	SetEndpoint("https://api.profitbricks.com/rest/v2")
+func setupTestEnv() {
 	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
+	SetEndpoint(os.Getenv("PROFITBRICKS_API_URL"))
 }

--- a/datacenter_test.go
+++ b/datacenter_test.go
@@ -1,14 +1,13 @@
 package profitbricks
 
 import (
-	"os"
 	"testing"
 )
 
 var dcID string
 
 func TestListDatacenters(t *testing.T) {
-	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
+	setupTestEnv()
 	want := 200
 
 	resp := ListDatacenters()
@@ -19,7 +18,6 @@ func TestListDatacenters(t *testing.T) {
 }
 
 func TestCreateDatacenter(t *testing.T) {
-	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
 	want := 202
 	var obj = Datacenter{
 		Properties: DatacenterProperties{
@@ -36,7 +34,6 @@ func TestCreateDatacenter(t *testing.T) {
 	}
 }
 func TestGetDatacenter(t *testing.T) {
-	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
 	want := 200
 	resp := GetDatacenter(dcID)
 	if resp.StatusCode != want {
@@ -45,7 +42,6 @@ func TestGetDatacenter(t *testing.T) {
 }
 
 func TestPatchDatacenter(t *testing.T) {
-	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
 	want := 202
 	newName := "Renamed DC"
 	obj := DatacenterProperties{Name: newName} //map[string]string{"name": "Renamed DC"}
@@ -61,7 +57,6 @@ func TestPatchDatacenter(t *testing.T) {
 }
 
 func TestDeleteDatacenter(t *testing.T) {
-	SetAuth(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
 	want := 202
 	resp := DeleteDatacenter(dcID)
 	if resp.StatusCode != want {

--- a/firewallrule_test.go
+++ b/firewallrule_test.go
@@ -48,9 +48,8 @@ func setup() {
 	nicid = datacenter.Entities.Servers.Items[0].Entities.Nics.Items[0].Id
 }
 func TestCreateFirewallRule(t *testing.T) {
+	setupTestEnv()
 	want := 202
-	setupCredentials()
-
 	setup()
 
 	fw := FirewallRule{
@@ -83,9 +82,7 @@ func TestGetFirewallRule(t *testing.T) {
 
 func TestListFirewallRules(t *testing.T) {
 	want := 200
-
 	fws := ListFirewallRules(dcID, srv_srvid, nicid)
-
 	if fws.StatusCode != want {
 		t.Error(fws.Response)
 		t.Errorf(bad_status(want, fws.StatusCode))
@@ -94,13 +91,10 @@ func TestListFirewallRules(t *testing.T) {
 
 func TestPatchFirewallRule(t *testing.T) {
 	want := 202
-
 	props := FirewallruleProperties{
 		Name: "updated",
 	}
-
 	fw := PatchFirewallRule(dcID, srv_srvid, nicid, fwId, props)
-
 	if fw.StatusCode != want {
 		t.Error(fw.Response)
 		t.Errorf(bad_status(want, fw.StatusCode))
@@ -113,7 +107,6 @@ func TestPatchFirewallRule(t *testing.T) {
 
 func TestDeleteFirewallRule(t *testing.T) {
 	want := 202
-
 	resp := DeleteFirewallRule(dcID, srv_srvid, nicid, fwId)
 
 	if resp.StatusCode != want {

--- a/image_test.go
+++ b/image_test.go
@@ -10,8 +10,7 @@ import (
 var imgid string
 
 func TestListImages(t *testing.T) {
-	setupCredentials()
-
+	setupTestEnv()
 	want := 200
 	resp := ListImages()
 

--- a/ipblock_test.go
+++ b/ipblock_test.go
@@ -6,7 +6,7 @@ import "testing"
 var ipblkid string
 
 func TestListIpBlocks(t *testing.T) {
-	setupCredentials()
+	setupTestEnv()
 	want := 200
 	resp := ListIpBlocks()
 	if resp.StatusCode != want {

--- a/lan_test.go
+++ b/lan_test.go
@@ -9,7 +9,7 @@ var lan_dcid string
 var lanid string
 
 func TestCreateLan(t *testing.T) {
-	setupCredentials()
+	setupTestEnv()
 	lan_dcid = mkdcid("GO SDK LAN DC")
 	want := 202
 	var request = Lan{

--- a/loadbalancer_test.go
+++ b/loadbalancer_test.go
@@ -11,7 +11,7 @@ var lbalid string
 var lbal_srvid string
 
 func TestCreateLoadbalancer(t *testing.T) {
-	setupCredentials()
+	setupTestEnv()
 	want := 202
 	lbal_dcid = mkdcid("GO SDK LB DC")
 	lbal_srvid = mksrvid(lbal_dcid)

--- a/location_test.go
+++ b/location_test.go
@@ -7,7 +7,7 @@ import (
 var locid string
 
 func TestListLocations(t *testing.T) {
-	setupCredentials()
+	setupTestEnv()
 	want := 200
 	resp := ListLocations()
 	if resp.StatusCode != want {

--- a/nic.go
+++ b/nic.go
@@ -25,6 +25,7 @@ type NicProperties struct {
 	Dhcp           bool     `json:"dhcp,omitempty"`
 	Lan            int      `json:"lan,omitempty"`
 	FirewallActive bool     `json:"firewallActive,omitempty"`
+	Nat            bool     `json:"nat,omitempty"`
 }
 
 type NicEntities struct {

--- a/nic_test.go
+++ b/nic_test.go
@@ -9,7 +9,7 @@ var nic_srvid string
 var nicid string
 
 func TestCreateNic(t *testing.T) {
-	setupCredentials()
+	setupTestEnv()
 	nic_dcid = mkdcid("GO SDK NIC DC")
 	nic_srvid = mksrvid(nic_dcid)
 
@@ -18,6 +18,7 @@ func TestCreateNic(t *testing.T) {
 		Properties: NicProperties{
 			Lan:  1,
 			Name: "Test NIC",
+			Nat:  false,
 		},
 	}
 

--- a/req.go
+++ b/req.go
@@ -32,7 +32,8 @@ func SetDepth(newdepth string) string {
 func mk_url(path string) string {
 	if strings.HasPrefix(path, "http") {
 		//REMOVE AFTER TESTING
-		path := strings.Replace(path, "https://api.profitbricks.com/rest/v2", Endpoint, 1)
+		//FIXME @jasmin Is this still relevant?
+		path := strings.Replace(path, "https://api.profitbricks.com/cloudapi/v3", Endpoint, 1)
 		// END REMOVE
 		return path
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -5,9 +5,8 @@ import (
 )
 
 func TestGetRequestStatus(t *testing.T) {
-	setupCredentials()
+	setupTestEnv()
 	want := 200
-	SetAuth("username", "password")
 	resp := GetRequestStatus("https://api.profitbricks.com/rest/v2/requests/2b31cc27-a604-4751-afc4-497b481e353d/status")
 	if resp.StatusCode != want {
 		t.Errorf(bad_status(want, resp.StatusCode))

--- a/server_test.go
+++ b/server_test.go
@@ -18,7 +18,7 @@ var (
 )
 
 func setupDataCenter() {
-	setupCredentials()
+	setupTestEnv()
 	srv_dc_id = mkdcid("GO SDK SERVER DC 02")
 	fmt.Println("Datacenter id: ", srv_dc_id)
 	if len(srv_dc_id) == 0 {

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -8,7 +8,7 @@ import (
 var snapshotId string
 
 func createVolume() {
-	setupCredentials()
+	setupTestEnv()
 	want := 202
 	var request = Volume{
 		Properties: VolumeProperties{

--- a/volume.go
+++ b/volume.go
@@ -21,6 +21,7 @@ type VolumeProperties struct {
 	Name                string   `json:"name,omitempty"`
 	Type                string   `json:"type,omitempty"`
 	Size                int      `json:"size,omitempty"`
+	AvailabilityZone    string   `json:"availabilityZone,omitempty"`
 	Image               string   `json:"image,omitempty"`
 	ImagePassword       string   `json:"imagePassword,omitempty"`
 	SshKeys             []string `json:"sshKeys,omitempty"`

--- a/volume_test.go
+++ b/volume_test.go
@@ -9,15 +9,16 @@ import (
 var volumeId string
 
 func TestCreateVolume(t *testing.T) {
-	setupCredentials()
+	setupTestEnv()
 	want := 202
 	var request = Volume{
 		Properties: VolumeProperties{
-			Size:          5,
-			Name:          "Volume Test",
-			Image:         "6aa59ab7-3f45-11e6-91c6-52540005ab80",
-			Type:          "HDD",
-			ImagePassword: "test1234",
+			Size:             5,
+			Name:             "Volume Test",
+			Image:            "6aa59ab7-3f45-11e6-91c6-52540005ab80",
+			Type:             "HDD",
+			ImagePassword:    "test1234",
+			AvailabilityZone: "ZONE_3",
 		},
 	}
 


### PR DESCRIPTION
#### Switch to Cloud API (previously REST API) v3. Changes are as below

1. `Endpoint` updated to use the v3 URL
2. REST v3 introduces Nat & Storage availability zone. `nat` property added to nic.go and `availability_zone` added to volume.go. 
3. Minor cleanup in tests