### PR TITLE
Fix nicProperties: Nat and FirewallActive could not be false

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/profitbricks/profitbricks-sdk-go
+
+require github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/helpers.go
+++ b/helpers.go
@@ -45,6 +45,11 @@ var (
 	snapshotdescription = "GO SDK test snapshot"
 )
 
+
+func boolAddr(v bool) *bool {
+	return &v
+}
+
 // Setup creds for single running tests
 func setupTestEnv() Client {
 	client := *NewClient(os.Getenv("PROFITBRICKS_USERNAME"), os.Getenv("PROFITBRICKS_PASSWORD"))
@@ -284,8 +289,8 @@ func mknicCustom(client Client, dcid, serverid string, lanid int, ips []string) 
 		Properties: &NicProperties{
 			Lan:            lanid,
 			Name:           "GO SDK Test",
-			Nat:            false,
-			FirewallActive: true,
+			Nat:            boolAddr(false),
+			FirewallActive: boolAddr(true),
 			Ips:            ips,
 		},
 	}

--- a/lan_test.go
+++ b/lan_test.go
@@ -77,7 +77,7 @@ func TestCreateCompositeLan(t *testing.T) {
 		Properties: &NicProperties{
 			Lan:  1,
 			Name: "Test NIC with failover",
-			Nat:  false,
+			Nat:  boolAddr(false),
 		},
 	}
 

--- a/nic.go
+++ b/nic.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 )
 
-//Nic object
+// Nic object
 type Nic struct {
 	ID         string         `json:"id,omitempty"`
 	PBType     string         `json:"type,omitempty"`
@@ -18,23 +18,23 @@ type Nic struct {
 	StatusCode int            `json:"statuscode,omitempty"`
 }
 
-//NicProperties object
+// NicProperties object
 type NicProperties struct {
 	Name           string   `json:"name,omitempty"`
 	Mac            string   `json:"mac,omitempty"`
 	Ips            []string `json:"ips,omitempty"`
 	Dhcp           *bool    `json:"dhcp,omitempty"`
 	Lan            int      `json:"lan,omitempty"`
-	FirewallActive bool     `json:"firewallActive,omitempty"`
-	Nat            bool     `json:"nat,omitempty"`
+	FirewallActive *bool    `json:"firewallActive,omitempty"`
+	Nat            *bool    `json:"nat,omitempty"`
 }
 
-//NicEntities object
+// NicEntities object
 type NicEntities struct {
 	FirewallRules *FirewallRules `json:"firewallrules,omitempty"`
 }
 
-//Nics object
+// Nics object
 type Nics struct {
 	ID         string       `json:"id,omitempty"`
 	PBType     string       `json:"type,omitempty"`

--- a/nic_test.go
+++ b/nic_test.go
@@ -32,8 +32,8 @@ func TestCreateNicFailure(t *testing.T) {
 	var request = Nic{
 		Properties: &NicProperties{
 			Name:           "GO SDK Test",
-			Nat:            false,
-			FirewallActive: true,
+			Nat:            boolAddr(false),
+			FirewallActive: boolAddr(true),
 			Ips:            []string{"10.0.0.1"},
 		},
 	}


### PR DESCRIPTION
*BREAKING CHANGE*: 
NicProperties.Nat and NicProperties.FirewallActive were bool and
tagged with omitEmpty, which made it impossible to set these to false
via sdk. To actually make use of optional attributes in a struct, the types must 
be references. 

Also add support for Go 1.11 modules