### PR TITLE
Adds new WaitTillProvisionedOrCanceled method

### DIFF
--- a/datacenter.go
+++ b/datacenter.go
@@ -1,8 +1,6 @@
 package profitbricks
 
 import (
-	"context"
-	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -93,43 +91,4 @@ func (c *Client) DeleteDatacenter(dcid string) (*http.Header, error) {
 	url := dcPath(dcid) + `?depth=` + c.client.depth + `&pretty=` + strconv.FormatBool(c.client.pretty)
 	ret := &http.Header{}
 	return ret, c.client.Delete(url, ret, http.StatusAccepted)
-}
-
-// WaitTillProvisionedOrCanceled waits for a request to be completed.
-// It returns an error if the request status could not be fetched, the request
-// failed or the given context is canceled.
-func (c *Client) WaitTillProvisionedOrCanceled(ctx context.Context, path string) error {
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			request, err := c.GetRequestStatus(path)
-			if err != nil {
-				return err
-			}
-			switch request.Metadata.Status {
-			case "DONE":
-				return nil
-			case "FAILED":
-				return errors.New("request failed")
-			}
-		}
-	}
-}
-
-// WaitTillProvisioned waits for a request to be completed.
-// It returns an error if the request status could not be fetched, the request
-// failed or a timeout of 2.5 minutes is exceeded.
-func (c *Client) WaitTillProvisioned(path string) (err error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 150*time.Second)
-	defer cancel()
-	if err = c.WaitTillProvisionedOrCanceled(ctx, path); err != nil {
-		if err == context.DeadlineExceeded {
-			return errors.New("timeout expired while waiting for request to complete")
-		}
-	}
-	return
 }

--- a/datacenter.go
+++ b/datacenter.go
@@ -1,7 +1,8 @@
 package profitbricks
 
 import (
-	"fmt"
+	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -94,19 +95,41 @@ func (c *Client) DeleteDatacenter(dcid string) (*http.Header, error) {
 	return ret, c.client.Delete(url, ret, http.StatusAccepted)
 }
 
-//WaitTillProvisioned helper function
-func (c *Client) WaitTillProvisioned(path string) error {
-	waitCount := 300
-	for i := 0; i < waitCount; i++ {
-		request, err := c.GetRequestStatus(path)
-		if err != nil {
-			return err
+// WaitTillProvisionedOrCanceled waits for a request to be completed.
+// It returns an error if the request status could not be fetched, the request
+// failed or the given context is canceled.
+func (c *Client) WaitTillProvisionedOrCanceled(ctx context.Context, path string) error {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			request, err := c.GetRequestStatus(path)
+			if err != nil {
+				return err
+			}
+			switch request.Metadata.Status {
+			case "DONE":
+				return nil
+			case "FAILED":
+				return errors.New("request failed")
+			}
 		}
-		if request.Metadata.Status == "DONE" {
-			return nil
-		}
-		time.Sleep(1 * time.Second)
-		i++
 	}
-	return fmt.Errorf("timeout expired while waiting for request to complete")
+}
+
+// WaitTillProvisioned waits for a request to be completed.
+// It returns an error if the request status could not be fetched, the request
+// failed or a timeout of 2.5 minutes is exceeded.
+func (c *Client) WaitTillProvisioned(path string) (err error) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 150*time.Second)
+	defer cancel()
+	if err = c.WaitTillProvisionedOrCanceled(ctx, path); err != nil {
+		if err == context.DeadlineExceeded {
+			return errors.New("timeout expired while waiting for request to complete")
+		}
+	}
+	return
 }

--- a/request_test.go
+++ b/request_test.go
@@ -48,12 +48,16 @@ func TestWaitTillProvisionedOrCanceled(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		err := c.WaitTillProvisionedOrCanceled(ctx, "a/path")
-		assert.Equal(t, context.Canceled, err)
+		if assert.Error(t, err) {
+			assert.Equal(t, context.Canceled, err)
+		}
 	})
 	t.Run("error getting request status", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		err := c.WaitTillProvisionedOrCanceled(ctx, "no/such/path")
-		assert.IsType(t, &url.Error{}, err)
+		if assert.Error(t, err) {
+			assert.IsType(t, &url.Error{}, err)
+		}
 	})
 }

--- a/request_test.go
+++ b/request_test.go
@@ -1,7 +1,9 @@
 package profitbricks
 
 import (
+	"context"
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +40,20 @@ func TestGetRequestFailure(t *testing.T) {
 	_, err := c.GetRequest("00000000-0000-0000-0000-000000000000")
 
 	assert.NotNil(t, err)
+}
+
+func TestWaitTillProvisionedOrCanceled(t *testing.T) {
+	c := setupTestEnv()
+	t.Run("cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := c.WaitTillProvisionedOrCanceled(ctx, "a/path")
+		assert.Equal(t, context.Canceled, err)
+	})
+	t.Run("error getting request status", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		err := c.WaitTillProvisionedOrCanceled(ctx, "no/such/path")
+		assert.IsType(t, &url.Error{}, err)
+	})
 }


### PR DESCRIPTION
It behaves like WaitTillProvisioned but does not abort after a a fixed
timeout of 2.5 minutes. Instead it accepts a context and aborts once the
context is canceled.

Both methods will now return an error if the request is completed but
failed.